### PR TITLE
witnesses strikethrough done for inactive ones

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 PORT=5000
-REACT_APP_API_ADDRESS=https://hafbe.openhive.network/hafbe
-REACT_APP_HIVE_BLOG_API_ADDRESS=https://api.hive.blog
+REACT_APP_API_ADDRESS=https://hiveapi.actifit.io/hafbe
+REACT_APP_HIVE_BLOG_API_ADDRESS=https://hiveapi.actifit.io

--- a/api/common/useWitnesses.ts
+++ b/api/common/useWitnesses.ts
@@ -11,8 +11,26 @@ const useWitnesses = (witnessesLimit: number) => {
     queryFn: () => fetchingService.getWitnesses(witnessesLimit, 0, "votes", "desc"),
     refetchOnWindowFocus: false,
   });
+  const {
+    data: activeWitnessesData,
+    isLoading: isActiveWitnessDataLoading,
+    isError: isActiveWitnessDataError,
+  } = useQuery({
+    queryKey: ["activeWitnesses"],
+    queryFn: async () => {
+      const witnesses = await fetchingService.getWitnessesByVote();
+      return witnesses.filter((witness: any) => witness.isActive);
+    },
+    refetchOnWindowFocus: false,
+  });
+  const isLoading = isWitnessDataLoading || isActiveWitnessDataLoading;
+  const isError = isWitnessDataError || isActiveWitnessDataError;
 
-  return { witnessesData, isWitnessDataLoading, isWitnessDataError };
+  return {
+    witnessesData,
+    activeWitnessesData,
+    isLoading,
+    isError,
+  };
 };
-
 export default useWitnesses;

--- a/api/common/useWitnesses.ts
+++ b/api/common/useWitnesses.ts
@@ -11,26 +11,7 @@ const useWitnesses = (witnessesLimit: number) => {
     queryFn: () => fetchingService.getWitnesses(witnessesLimit, 0, "votes", "desc"),
     refetchOnWindowFocus: false,
   });
-  const {
-    data: activeWitnessesData,
-    isLoading: isActiveWitnessDataLoading,
-    isError: isActiveWitnessDataError,
-  } = useQuery({
-    queryKey: ["activeWitnesses"],
-    queryFn: async () => {
-      const witnesses = await fetchingService.getWitnessesByVote();
-      return witnesses.filter((witness: any) => witness.isActive);
-    },
-    refetchOnWindowFocus: false,
-  });
-  const isLoading = isWitnessDataLoading || isActiveWitnessDataLoading;
-  const isError = isWitnessDataError || isActiveWitnessDataError;
-
-  return {
-    witnessesData,
-    activeWitnessesData,
-    isLoading,
-    isError,
-  };
+ 
+    return { witnessesData, isWitnessDataLoading, isWitnessDataError};
 };
 export default useWitnesses;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2300,9 +2300,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001561",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001561.tgz",
-      "integrity": "sha512-NTt0DNoKe958Q0BE0j0c1V9jbUzhBxHIEJy7asmGrpE0yG63KTV7PLHPnK2E1O9RsQrQ081I3NLuXGS6zht3cw==",
+      "version": "1.0.30001643",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001643.tgz",
+      "integrity": "sha512-ERgWGNleEilSrHM6iUz/zJNSQTP8Mr21wDWpdgvRwcTXGAq6jMtOUPP4dqFPTdKqZ2wKTdtB+uucZ3MRpAUSmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -8179,9 +8179,9 @@
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001561",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001561.tgz",
-      "integrity": "sha512-NTt0DNoKe958Q0BE0j0c1V9jbUzhBxHIEJy7asmGrpE0yG63KTV7PLHPnK2E1O9RsQrQ081I3NLuXGS6zht3cw=="
+      "version": "1.0.30001643",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001643.tgz",
+      "integrity": "sha512-ERgWGNleEilSrHM6iUz/zJNSQTP8Mr21wDWpdgvRwcTXGAq6jMtOUPP4dqFPTdKqZ2wKTdtB+uucZ3MRpAUSmg=="
     },
     "chalk": {
       "version": "4.1.2",

--- a/pages/witnesses.tsx
+++ b/pages/witnesses.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import Link from "next/link";
 import { Loader2, MenuSquareIcon } from "lucide-react";
+import {  formatFeedAge, isFeedAgeBeyondThreshold} from "@/utils/TimeUtils";
+
 import {
   Table,
   TableBody,
@@ -156,9 +158,10 @@ export default function Witnesses() {
                     ? singleWitness.price_feed.toLocaleString()
                     : "--"}
                 </TableCell>
-                <TableCell>
-                  {singleWitness.feed_age
-                    ? singleWitness.feed_age.split(".")[0]
+                <TableCell
+                className={
+                    isFeedAgeBeyondThreshold(singleWitness.feed_age, 3)? "text-red-500": ""}>
+                  {singleWitness.feed_age ? formatFeedAge(singleWitness.feed_age)
                     : "--"}
                 </TableCell>
                 <TableCell>{singleWitness.version}</TableCell>

--- a/pages/witnesses.tsx
+++ b/pages/witnesses.tsx
@@ -21,17 +21,19 @@ export default function Witnesses() {
   const [isVotersOpen, setIsVotersOpen] = useState<boolean>(false);
   const [isVotesHistoryOpen, setIsVotesHistoryOpen] = useState<boolean>(false);
 
-  const { witnessesData, isWitnessDataLoading } = useWitnesses(
+  const { witnessesData, activeWitnessesData, isLoading, isError } = useWitnesses(
     config.witnessesPerPages.witnesses
   );
 
-  if (isWitnessDataLoading) {
+  if (isLoading) {
     return (
       <Loader2 className="dark:text-white animate-spin mt-1 h-8 w-8 ml-3 ..." />
     );
   }
 
   if (!witnessesData || !witnessesData.length) return;
+  if (isError || !witnessesData || !witnessesData.length) return null;
+
 
   const changeVotersDialogue = (isOpen: boolean) => {
     setIsVotersOpen(isOpen);
@@ -76,7 +78,7 @@ export default function Witnesses() {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {witnessesData.map((singleWitness, index) => (
+            {witnessesData.map((singleWitness: any, index: number) => (
               <TableRow
                 key={index}
                 className={`${index % 2 === 0 ? "bg-gray-800" : "bg-gray-900"}`}
@@ -106,6 +108,7 @@ export default function Witnesses() {
                   <Link
                     href={`/@${singleWitness.witness}`}
                     data-testid="witness-name"
+                    className={singleWitness.signing_key === "STM1111111111111111111111111111111114T1Anm" ? "line-through" : ""}
                   >
                     {singleWitness.witness}
                   </Link>

--- a/pages/witnesses.tsx
+++ b/pages/witnesses.tsx
@@ -21,18 +21,15 @@ export default function Witnesses() {
   const [isVotersOpen, setIsVotersOpen] = useState<boolean>(false);
   const [isVotesHistoryOpen, setIsVotesHistoryOpen] = useState<boolean>(false);
 
-  const { witnessesData, activeWitnessesData, isLoading, isError } = useWitnesses(
+  const { witnessesData, isWitnessDataLoading } = useWitnesses(
     config.witnessesPerPages.witnesses
   );
 
-  if (isLoading) {
-    return (
-      <Loader2 className="dark:text-white animate-spin mt-1 h-8 w-8 ml-3 ..." />
-    );
+  if (isWitnessDataLoading) {
+    return <Loader2 className="dark:text-white animate-spin mt-1 h-8 w-8 ml-3 ..." />;
   }
 
   if (!witnessesData || !witnessesData.length) return;
-  if (isError || !witnessesData || !witnessesData.length) return null;
 
 
   const changeVotersDialogue = (isOpen: boolean) => {

--- a/services/FetchingService.ts
+++ b/services/FetchingService.ts
@@ -23,30 +23,7 @@ class FetchingService {
     this.nodeUrl = newUrl;
   }
  
-  async getWitnessesByVote(): Promise<any> {
-    const response = await fetch("https://api.hive.blog", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        method: "condenser_api.get_witnesses_by_vote",
-        id: 1,
-        params: [null, 200] 
-      }),
-    });
-
-    const data = await response.json();
-
-    if (data.result) {
-      return data.result.map((witness: any) => ({
-        ...witness,
-        isActive: witness.signing_key !== "STM1111111111111111111111111111111114T1Anm"
-      }));
-    }
-
-    throw new Error("Failed to fetch witnesses by vote");
-  }
-
+  
   public setHiveChain(hiveChain: IHiveChainInterface | null) {
     this.extendedHiveChain = hiveChain?.extend<ExplorerNodeApi>();
     if (this.extendedHiveChain && this.nodeUrl) {
@@ -215,7 +192,12 @@ class FetchingService {
       _order_by: orderBy,
       _order_is: orderIs,
     };
-    return await this.callApi("get_witnesses", requestBody);
+    const witnesses = await this.callApi("get_witnesses", requestBody);
+
+    return witnesses.map((witness: Hive.Witness) => ({
+      ...witness,
+      isActive: witness.signing_key !== "STM1111111111111111111111111111111114T1Anm"
+    }));
   }
 
   async getWitnessesVotersNum(witness: string): Promise<unknown> {

--- a/services/FetchingService.ts
+++ b/services/FetchingService.ts
@@ -22,6 +22,30 @@ class FetchingService {
   public setNodeUrl(newUrl: string) {
     this.nodeUrl = newUrl;
   }
+ 
+  async getWitnessesByVote(): Promise<any> {
+    const response = await fetch("https://api.hive.blog", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "condenser_api.get_witnesses_by_vote",
+        id: 1,
+        params: [null, 200] 
+      }),
+    });
+
+    const data = await response.json();
+
+    if (data.result) {
+      return data.result.map((witness: any) => ({
+        ...witness,
+        isActive: witness.signing_key !== "STM1111111111111111111111111111111114T1Anm"
+      }));
+    }
+
+    throw new Error("Failed to fetch witnesses by vote");
+  }
 
   public setHiveChain(hiveChain: IHiveChainInterface | null) {
     this.extendedHiveChain = hiveChain?.extend<ExplorerNodeApi>();

--- a/utils/TimeUtils.ts
+++ b/utils/TimeUtils.ts
@@ -10,3 +10,35 @@ export const formatAndDelocalizeTime = (date?: string | Date): string => {
   if (!date) return "";
   return moment(date).format(config.baseMomentTimeFormat);
 }
+
+
+export function formatFeedAge(feedAge: string): string {
+  if (!feedAge) return "--";
+  const [hoursStr, minutesStr, secondsStr] = feedAge.split(":");
+  const hours = parseInt(hoursStr, 10) || 0;
+  const minutes = parseInt(minutesStr, 10) || 0;
+  const seconds = parseInt(secondsStr, 10) || 0;
+  const dayMatch = feedAge.match(/(\d+)\s*days?/);
+  const days = dayMatch ? parseInt(dayMatch[1], 10) : 0;
+  const totalMinutes = hours * 60 + minutes;
+  const totalHours = hours + minutes / 60;
+  if (days > 0) {
+    return days === 1 ? "1 day" : `${days} days`;
+  } else if (totalHours >= 1) {
+    const minutesPart = minutes > 0 ? ` ${minutes} min${minutes > 1 ? 's' : ''}` : '';
+    return Math.floor(totalHours) === 1 ? `1 hour${minutesPart}` : `${Math.floor(totalHours)} hours${minutesPart}`;
+  } else if (totalMinutes >= 1) {
+    return Math.floor(totalMinutes) === 1 ? "1 min" : `${Math.floor(totalMinutes)} mins`;
+  } else {
+    return "0 mins";
+  }
+}
+export function isFeedAgeBeyondThreshold(feedAge: string, thresholdInDays: number): boolean {
+  if (!feedAge) return false;
+  const [hours, minutes] = feedAge.split(":").map(Number);
+  const totalMinutes = hours * 60 + minutes;
+  const dayMatch = feedAge.match(/(\d+)\s*days?/);
+  const days = dayMatch ? parseInt(dayMatch[1], 10) : 0;
+
+  return days > thresholdInDays;
+}


### PR DESCRIPTION
i have researched how The getactivewtinesses API you suggested  works and it call to return exactly 21 active witnesses bceasuse the Hive blockchain is designed to always have 21 active witnesses producing blocks at any given time.
after trying out multiple apis, i found get witnesses by vote API and what is special about it is from the returned data which most of is not relevant you can check the signing key attribute to determine their if they are active or not so basically a value of STM1111111111111111111111111111111114T1Anm for  it  would mean the witness is deactivated and will not be scheduled for block production so we can use that so that if it matches it means the witness has it  disbaled